### PR TITLE
[BRI-331] signedMetaDelegateCall test that executes a signed strategy

### DIFF
--- a/test/Account_signedMetaDelegateCall.sol
+++ b/test/Account_signedMetaDelegateCall.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "./Helper.sol";
+
+contract Account_signedMetaDelegateCall is Test, Helper  {
+
+  function setUp () public {
+    setupAll(BLOCK_FEB_12_2023);
+  }
+
+  // test for signed metaDelegateCall
+  function testAccount_signedMetaDelegateCall () public {
+    setupFiller();
+    setupProxy0();
+
+    bytes memory twapAdapterParams = abi.encode(address(USDC_ETH_FEE500_UNISWAP_V3_POOL), uint32(1000));
+    uint usdcInAmount = 1450_000000;
+    uint24 feePercent = 10000; // 1%
+    uint feeMin = 0; // no minimum fixed fee
+
+    uint expectedRequiredWethOutAmount = primitives.getSwapAmountWithFee(twapAdapter, twapAdapterParams, usdcInAmount, -int24(feePercent), int(feeMin));
+    int intWethOutAmount = int(expectedRequiredWethOutAmount);
+    
+    // fill with exact expectedRequiredWethOutAmount. for a real market swap, filler could provide an additional amount as buffer for
+    // price movement to avoid revert
+    bytes memory fillCall = abi.encodeWithSelector(filler.fill.selector, WETH, TokenStandard.ERC20, proxy0_signerAddress, expectedRequiredWethOutAmount, new uint[](0));
+
+    Primitive[] memory primitives_order0 = new Primitive[](2);
+    
+    // useBit primitive
+    primitives_order0[0] = Primitive(
+      abi.encodeWithSelector(Primitives01.useBit.selector, 0, 1),
+      false
+    );
+
+    // marketSwapExactInput primitive
+    primitives_order0[1] = Primitive(
+      abi.encodeWithSelector(
+        Primitives01.marketSwapExactInput.selector,
+        twapAdapter,
+        twapAdapterParams,
+        proxy0_signerAddress,
+        USDC_Token,
+        WETH_Token,
+        usdcInAmount,
+        feePercent,
+        feeMin,
+        new bytes(0) // add an empty dynamic bytes, which will be overwritten by UnsignedMarketSwapData
+      ),
+      true
+    );
+
+    Order[] memory orders = new Order[](1);
+    orders[0] = Order(primitives_order0);
+
+    bytes[] memory unsignedCalls = new bytes[](1);
+
+    // encode the UnsignedMarketSwapData.
+    // don't wrap in UnsignedMarketSwapData() struct type because this adds additional data that will break the call
+    unsignedCalls[0] = abi.encode(
+      address(filler),
+      EMPTY_IDS_PROOF,
+      EMPTY_IDS_PROOF,
+      Call(address(filler), fillCall)
+    );
+
+    bytes memory data = strategyExecuteData(orders, new Call[](0), new Call[](0));
+    bytes32 msgHash = messageHash(address(strategyTarget), data, address(proxy0_account));
+    bytes memory signature = signMessageHash(proxy0_signerPrivateKey, msgHash);
+    bytes memory unsignedData = abi.encode(0, unsignedCalls);
+
+    startBalances(address(filler));
+    startBalances(proxy0_signerAddress);
+
+    vm.prank(proxy0_signerAddress);
+    USDC_ERC20.approve(address(proxy0_account), 1450_000000);
+
+    proxy0_account.metaDelegateCall(address(strategyTarget), data, signature, unsignedData);
+
+    endBalances(address(filler));
+    endBalances(proxy0_signerAddress);
+
+    assertEq(diffBalance(USDC, proxy0_signerAddress), -1450_000000);
+    assertEq(diffBalance(USDC, address(filler)), 1450_000000);
+    assertEq(diffBalance(WETH, proxy0_signerAddress), intWethOutAmount);
+    assertEq(diffBalance(WETH, address(filler)), -intWethOutAmount);
+  }
+
+  function strategyExecuteData (
+    Order[] memory orders,
+    Call[] memory beforeCalls,
+    Call[] memory afterCalls
+  ) public view returns (bytes memory data) {
+    // encode strategy data without using Strategy struct
+    bytes memory strategyData = abi.encode(
+      address(primitives),
+      orders,
+      beforeCalls,
+      afterCalls
+    );
+
+    // create a memory pointer to the encoded strategy data, which starts after 64 bytes (after the two pointers)
+    bytes32 strategyPtr = 0x0000000000000000000000000000000000000000000000000000000000000040;
+
+    // create a memory pointer to where unsigned data will be appended,
+    // which will be after 64 bytes (for the two pointers) plus the length of the encoded strategy
+    bytes32 unsignedDataPtr = bytes32(strategyData.length + 0x40); 
+
+    data = bytes.concat(
+      strategyTarget.execute.selector, // bytes4: fn selector
+      strategyPtr,        // bytes32: memory pointer to strategy data
+      unsignedDataPtr,    // bytes32: memory pointer to unsigned data
+      strategyData        // bytes: encoded strategy
+    );
+  }
+
+  function messageHash (
+    address to,
+    bytes memory data,
+    address account
+  ) public view returns (bytes32 messageHash) {
+    bytes32 dataHash = keccak256(
+      abi.encode(
+        keccak256("MetaDelegateCall(address to,bytes data)"), // META_DELEGATE_CALL_TYPEHASH
+        to,
+        keccak256(data)
+      )
+    );
+    messageHash = keccak256(abi.encodePacked(
+      "\x19\x01",
+      keccak256(abi.encode(
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+        keccak256("BrinkAccount"),
+        keccak256("1"),
+        block.chainid,
+        account
+      )),
+      dataHash
+    ));
+  }
+
+  function signMessageHash (
+    bytes32 privateKey,
+    bytes32 messageHash
+  ) public view returns (bytes memory signature) {
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(uint(privateKey), messageHash);
+    signature = abi.encodePacked(r, s, v);
+  }
+
+}

--- a/test/Interfaces/IAccount.sol
+++ b/test/Interfaces/IAccount.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+interface IAccount {
+  function metaDelegateCall(
+    address to, bytes calldata data, bytes calldata signature, bytes calldata unsignedData
+  ) external payable;
+}

--- a/test/Interfaces/IAccountFactory.sol
+++ b/test/Interfaces/IAccountFactory.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+interface IAccountFactory {
+  function deployAccount(address owner) external returns (address account);
+}

--- a/test/StrategyTarget01_execute_multiOrder.sol
+++ b/test/StrategyTarget01_execute_multiOrder.sol
@@ -120,8 +120,10 @@ contract StrategyTarget01_execute_multiOrder is Test, Helper  {
     vm.expectRevert(BitNotUsed.selector);
     strategyTarget.execute(
       strategy,
-      1, // order0
-      unsignedCalls_fillOrder1
+      UnsignedData(
+        1, // order0
+        unsignedCalls_fillOrder1
+      )
     );
 
     // track balances and execute the USDC->WETH order
@@ -129,8 +131,10 @@ contract StrategyTarget01_execute_multiOrder is Test, Helper  {
     startBalances(TRADER_1);
     strategyTarget.execute(
       strategy,
-      0, // order0
-      unsignedCalls_fillOrder0
+      UnsignedData(
+        0, // order0
+        unsignedCalls_fillOrder0
+      )
     );
     endBalances(address(filler));
     endBalances(TRADER_1);
@@ -144,8 +148,10 @@ contract StrategyTarget01_execute_multiOrder is Test, Helper  {
     startBalances(TRADER_1);
     strategyTarget.execute(
       strategy,
-      1, // order0
-      unsignedCalls_fillOrder1
+      UnsignedData(
+        1, // order0
+        unsignedCalls_fillOrder1
+      )
     );
     endBalances(address(filler));
     endBalances(TRADER_1);

--- a/test/StrategyTarget01_execute_reverts.sol
+++ b/test/StrategyTarget01_execute_reverts.sol
@@ -26,8 +26,10 @@ contract StrategyTarget01_execute_reverts is Test, Helper  {
     vm.expectRevert(BadOrderIndex.selector);
     strategyTarget.execute(
       strategy,
-      1, // strategy only has order0, index 1 is out of bounds
-      new bytes[](0)
+      UnsignedData(
+        1, // strategy only has order0, index 1 is out of bounds
+        new bytes[](0)
+      )
     );
   }
 
@@ -47,8 +49,10 @@ contract StrategyTarget01_execute_reverts is Test, Helper  {
     vm.expectRevert(UnsignedCallRequired.selector);
     strategyTarget.execute(
       strategy,
-      0,
-      new bytes[](0) // no unsigned call provided
+      UnsignedData(
+        0,
+        new bytes[](0) // no unsigned call provided
+      )
     );
   }
 

--- a/test/StrategyTarget01_execute_singleOrder.sol
+++ b/test/StrategyTarget01_execute_singleOrder.sol
@@ -73,6 +73,8 @@ contract StrategyTarget01_execute_singleOrder is Test, Helper  {
       new Call[](0)
     );
 
+    UnsignedData memory unsignedData = UnsignedData(0, unsignedCalls);
+
     startBalances(address(filler));
     startBalances(TRADER_1);
 
@@ -81,8 +83,7 @@ contract StrategyTarget01_execute_singleOrder is Test, Helper  {
 
     strategyTarget.execute(
       strategy,
-      0, // order0
-      unsignedCalls
+      unsignedData
     );
 
     endBalances(address(filler));


### PR DESCRIPTION
proof of concept to show how signed/unsigned data works with `StrategyTarget01.execute()`. Added the `UnsignedData` struct to execute params because it's easier to deal with encoding memory pointers